### PR TITLE
Increase CI server resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ##Deployment architecture
 
-![](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/omahoito/definitions/master/deployment.md?30) <!--- This generates a picture based on deployment.MD. To change the counter in the url above, i.e. deployment.MD?13 -> deployment.MD?14 --->
+![](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/omahoito/definitions/master/deployment.md?31) <!--- This generates a picture based on deployment.md. To change the counter in the url above, i.e. deployment.md?13 -> deployment.md?14 --->
 
 ###Peruskokoonpanot
 ####Peruskokoonpano 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@
 - 250G+ SSD storage
 - 4 NIC
 
+####Continuous Integration Server
+- 1 kappale
+- CentOS 7, Ubuntu 16 or Debian 8
+- 32G+ RAM
+- 8+ CPU
+- 250G+ SSD storage
+- 4 NIC
+
 ###Kapasiteettipalveluja
 - Backup
 

--- a/deployment.md
+++ b/deployment.md
@@ -89,7 +89,7 @@ CentOS 7, Ubuntu 16 or Debian 8
 32G+ RAM
 8+ CPU
 250G+ SSD storage
-2 NIC
+4 NIC
 ]
 node nodevm [
 Temporary Server 

--- a/deployment.md
+++ b/deployment.md
@@ -87,7 +87,7 @@ Continuous Integration Server
 CentOS 7, Ubuntu 16 or Debian 8
 ....
 32G+ RAM
-4+ CPU
+8+ CPU
 250G+ SSD storage
 2 NIC
 ]


### PR DESCRIPTION
CI server should have as many CPU cores as there will be concurrent build, test and deployment jobs. Taking account the number of repositories and developers, 8 cores would be a better guess than 4 in my opinion.

CI server should have access to all proxy, application and db servers in order to deploy configuration and software. Therefore I propose increasing the number of NICs to match the number of networks. Although, with proper routing the original number of 2 could be sufficient.