### PR TITLE
Add get pre-population data from Omakanta omatietovaranto

### DIFF
--- a/sequence-diagrams/README.md
+++ b/sequence-diagrams/README.md
@@ -2,7 +2,7 @@
 
 ###Symptom check - authenticated user
 
-![](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/kainutom/definitions/master/sequence-diagrams/symptom-check-authenticated-user.puml?2) <!--- This generates a picture based on *.puml. To change the counter in the url above, i.e. *.puml?13 -> *.puml?14 --->
+![](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/kainutom/definitions/master/sequence-diagrams/symptom-check-authenticated-user.puml?3) <!--- This generates a picture based on *.puml. To change the counter in the url above, i.e. *.puml?13 -> *.puml?14 --->
 
 
 

--- a/sequence-diagrams/symptom-check-authenticated-user.puml
+++ b/sequence-diagrams/symptom-check-authenticated-user.puml
@@ -30,9 +30,12 @@ ODA_WEB_UI -> ODA_FHIR_API: POST [oda-fhir-base]/Questionnaire/[id]/$populate
 ODA_FHIR_API -> ODA_PHR: GET [phr-fhir-base]/Questionnaire/[id]
 ODA_FHIR_API <-- ODA_PHR: HTTP 200 OK  [Questionnaire]
 
-ODA_FHIR_API -> OMAKANTA: GET [omakanta data for pre-population purposes]
-ODA_FHIR_API <- OMAKANTA: HTTP 200 OK [omakanta data for pre-population purposes]
-ODA_FHIR_API -> ODA_FHIR_API: Pre-populate the questionnaireResponse
+ODA_FHIR_API -> ODA_FHIR_API: resolve pre-population Observation codes from Questionnaire
+ODA_FHIR_API -> ODA_PHR: GET [oda-fhir-base]/Observation?code=[system]|[code],[system]|[code],[system]|[code] ...
+ODA_FHIR_API <- ODA_PHR: HTTP 200 OK [Bundle - collection of latest observations]
+ODA_FHIR_API -> ODA_PHR: GET [oda-fhir-base]/QuestionnaireResponse?questionnaire=[id]
+ODA_FHIR_API <- ODA_PHR: HTTP 200 OK [Latest QuestionnaireResponse for Questionnaire]
+ODA_FHIR_API -> ODA_FHIR_API: Pre-populate the QuestionnaireResponse [use Observations and latest QuestionnaireResponse]
 
 ODA_WEB_UI <-- ODA_FHIR_API: HTTP 200 OK  [QuestionnaireResponse]
 


### PR DESCRIPTION
Add get pre-population data from Omakanta omatietovaranto (kela-phr or oda-phr) to symptom check activity diagram.

Pre-population data can contain observations and the latest questionnaire response to the same questionnaire.