### PR TITLE
Use IntegrationTestRule as ClassRule

### DIFF
--- a/codeconventions.md
+++ b/codeconventions.md
@@ -48,8 +48,8 @@ ODA source code is developed on various platforms and editors. Therefore common 
 ```
 public class SomeIT {
 
-    @Rule
-    public IntegrationTestRule integrationTestRule = new IntegrationTestRule();
+    @ClassRule
+    public static IntegrationTestRule integrationTestRule = new IntegrationTestRule();
 
     ...
 ```


### PR DESCRIPTION
When IntegrationTestRule is used as ClassRule the test is skipped before building Spring context which results in much faster test execution.